### PR TITLE
[TABLE LINKBASE] Fixes for rendering for a german taxonomy (HGB) using relationship nodes

### DIFF
--- a/arelle/rendering/RenderingResolution.py
+++ b/arelle/rendering/RenderingResolution.py
@@ -279,7 +279,8 @@ def resolveDefinition(view, strctMdlParent, defnMdlNode, depth, facts, iBrkdn=No
             strctMdlNode = strctMdlParent # all children are added during relationship navigatio below
         else:
             strctMdlNode = StrctMdlStructuralNode(strctMdlParent, defnMdlNode)
-    axis = strctMdlParent.axis
+    if strctMdlParent.axis:
+        axis = strctMdlParent.axis
 
     subtreeRels = view.defnSubtreeRelSet.fromModelObject(defnMdlNode)
 
@@ -320,7 +321,15 @@ def resolveDefinition(view, strctMdlParent, defnMdlNode, depth, facts, iBrkdn=No
             elif axis == "y":
                 if ordDepth:
                     if nestedDepth > view.rowHdrCols:
-                        view.rowHdrCols = nestedDepth - 1
+                        view.rowHdrCols = nestedDepth
+                        if not isinstance(defnMdlNode, DefnMdlRelationshipNode):
+                            # not quite sure of this condition, but Solvency (rule node) need one less col than a relationship node (german taxonomy)
+                            view.rowHdrCols -= 1
+                        for j in range(1 + ordDepth):
+                            view.rowHdrColWidth.append(RENDER_UNITS_PER_CHAR)  # min width for 'tail' of nonAbstract coordinate
+                            view.rowNonAbstractHdrSpanMin.append(0)
+                    elif isinstance(strctMdlNode, StrctMdlBreakdown):
+                        view.rowHdrCols = view.rowHdrCols + nestedDepth
                         for j in range(1 + ordDepth):
                             view.rowHdrColWidth.append(RENDER_UNITS_PER_CHAR)  # min width for 'tail' of nonAbstract coordinate
                             view.rowNonAbstractHdrSpanMin.append(0)


### PR DESCRIPTION
#### Reason for change
While testing a German taxonomy, I found some problems with the relationship node that didn't render correctly (tested with this branch since it already contains many changes for the relationships nodes)
This Pr contains the changes needed to have the correct renders.

When running the conformance suite in the GUI, the results are as follows on my side:

|        | Pass | Fails |
|--------|------|-------|
| Before | 235  | 123   |
| After  | 237  | 121   |

Note that those result are way off compared to the test case, but if I try to run the test case, it does nothing for some reason.

#### Description of change
Most changes are in the rendering side, dealing with row/col span and things like that.
The only change in the model is the multiples breakdowns (https://www.xbrl.org/Specification/table-linkbase/REC-2014-03-18+errata-2018-07-17/table-linkbase-REC-2014-03-18+corrected-errata-2018-07-17.html#sec-layout-projection) which wasn't combining correctly.

#### Steps to Test
* Run the conformance suite

Or
* Download and open the german taxonomy: https://publikations-plattform.de, "Work aids & standards" > "XBRL taxonomy for annual financial statements", it's the "XBRL taxonomy in accordance with HGB 6.7" (you need to give your email to download it)

**review**:
@hermfischer-wf 
