### PR TITLE
Add schema xs:pattern check for illegal escapes

### DIFF
--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -46,6 +46,7 @@ standard_roles_definitions = {
 standard_roles_other = ("xbrl.5.1.3", ())
 
 inlineDisplayNonePattern = re.compile(r"display\s*:\s*none")
+illegalXsdPatternEscapeChar = re.compile(r"\\[^nrt\\.^?*+{}()[\]pPsSiIcCdDwW-]")
 
 def arcFromConceptQname(arcElement):
     modelRelationship = baseSetRelationship(arcElement)
@@ -517,7 +518,14 @@ def checkElements(val, modelDocument, parent):
                         if val.validateSBRNL and localName == "attribute":
                             val.modelXbrl.error("SBR.NL.2.2.11.06",
                                 _('xs:attribute must not be used'), modelObject=elt)
-
+                    if localName == "pattern":
+                        value = elt.get("value")
+                        if value is not None:
+                            illegalEscapes =  illegalXsdPatternEscapeChar.findall(value)
+                            if illegalEscapes:
+                                val.modelXbrl.error("xmlSchema:patternEscapeDisallowed",
+                                    _("%(element)s contains disallowed escape %(escapes)s"),
+                                    modelObject=elt, element=localName, escapes=", ".join(illegalEscapes))
                     if localName == "appinfo":
                         if val.validateSBRNL:
                             if (parent.localName != "annotation" or parent.namespaceURI != XbrlConst.xsd or


### PR DESCRIPTION
base spec conf test v401-05 check schema pattern element value for legal escapes

#### Reason for change
test v401-05 expects this change

#### Description of change
check escape characters

#### Steps to Test
base spec conf test v401-05

**review**:
@Arelle/arelle
